### PR TITLE
Add ansible migration step and dockerignore (DVZO-79)

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,15 @@
+.bandit
+.editorconfig
+.env.example
+.git
+.gitignore
+CODE_OF_CONDUCT.md
+LICENSE
+README.md
+/ansible/
+azure-pipelines.yml
+/build/
+db_helper.py
+db_helper.sh
+/dist/
+/dvzo.egg-info/

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -5,7 +5,11 @@
 - `ansible` installed locally
 - `centos/8` server (change ip in hosts if it changes)
 
-Install docker-compose module:
+### Ansible Galaxy Packages
+
+```
+ansible-galaxy collection install community.general
+```
 
 ## Setup Server
 

--- a/ansible/roles/run-deployment/tasks/main.yml
+++ b/ansible/roles/run-deployment/tasks/main.yml
@@ -38,3 +38,8 @@
 - name: Check debug log of dvzo services
   ansible.builtin.debug:
     var: output
+
+- name: Migrate database
+  shell:
+    cmd: "docker-compose exec dvzo_container python manage.py migrate"
+    chdir: /root/dvzo/


### PR DESCRIPTION
To make sure that migrations are executed on deploying a new container the new step runs them every time it is newly deployed.

The docker ignore file defines which files are not copied into the container on build time.
I removed all the package config files from the container.

Close https://dvzo.atlassian.net/browse/DVZO-79