### PR TITLE
Provide executable for pip and fix serving resource.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,13 +3,12 @@
 .env.example
 .git
 .gitignore
+db.sqlite3
 CODE_OF_CONDUCT.md
 LICENSE
-README.md
 /ansible/
 azure-pipelines.yml
 /build/
 db_helper.py
-db_helper.sh
 /dist/
 /dvzo.egg-info/

--- a/ansible/roles/run-deployment/tasks/main.yml
+++ b/ansible/roles/run-deployment/tasks/main.yml
@@ -8,10 +8,12 @@
   pip:
     name: pip
     state: latest
+    executable: /usr/local/bin/pip3
 
 - name: Install prerequisites (python packages)
   pip:
     name: ['docker', 'PyYAML', 'docker-compose']
+    executable: /usr/local/bin/pip3
 
 - name: Ensures /home/dvzo/app dir exists
   file: path=/home/dvzo/app state=directory
@@ -29,6 +31,7 @@
     state: absent
     remove_images: all
     remove_volumes: no
+  ignore_errors: yes
 
 - name: Create and start dvzo services
   community.docker.docker_compose:

--- a/dvzo/settings.py
+++ b/dvzo/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     'django_tex',
     'phonenumber_field',
     'tapeforms',
+    'compressor',
 ] + PROJECT_APPS
 
 MIDDLEWARE = [
@@ -46,18 +47,11 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-
 AUTH_USER_MODEL = 'users.User'
-
 
 STATIC_ROOT = BASE_DIR / 'staticfiles'
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [BASE_DIR / 'static']
-STATICFILES_FINDERS = [
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 PHONENUMBER_DEFAULT_REGION = "CH"
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ URL = 'https://github.com/osswald/dvzo'
 REQUIRED = [
     'Pillow',
     'gunicorn',
+    'django-compressor',
     'django_tex',
     'Django',
     'python-dotenv',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: 'auxiliary.css'
+      filename: 'auxiliary.min.css'
     }),
     new MiniCssExtractPlugin({
       filename: '[name].css',


### PR DESCRIPTION
This PR fixes the deployment so that static files are served again.

Also it renames the dockerignore to actually do it's job. And the third change is fixing the ansible script providing the executable path for pip.

![image](https://user-images.githubusercontent.com/29920936/117556895-0b746280-b06e-11eb-9167-2811cd749051.png)
