### PR TITLE
filter phone numbers to show correctly (DVZO-123)

### DIFF
--- a/train_management/views/phonenumber.py
+++ b/train_management/views/phonenumber.py
@@ -59,6 +59,7 @@ class PhoneNumberDetail(generic.ListView):
 
 @method_decorator(login_required, name='dispatch')
 class PhoneNumberMemberList(generic.ListView):
-    queryset = Personnel.objects.filter(status="active", mobile_phone_public=True).order_by("user__last_name")
+    queryset = Personnel.objects.filter(status="active", mobile_phone_public="yes")\
+        .exclude(mobile_phone="").order_by("user__last_name")
     template_name = "train_management/phonenumber_member.html"
     context_object_name = "phone_numbers"


### PR DESCRIPTION
only numbers of active personnel where
mobile_phone_public is set to yes are allowed
to be shown.
also don't show personnel with no phone
number