### PR TITLE
Change display behaviour of reservation link on dayplanning

### DIFF
--- a/train_management/templates/train_management/dayplanning_detail_form.html
+++ b/train_management/templates/train_management/dayplanning_detail_form.html
@@ -296,9 +296,11 @@
                   </a>
                   {% endif %}
                   {% if perms.train_management.add_reservation %}
+                  {% if traintimetable.reservation_internal == "possible" %}
                   <a href="{% url 'reservation-create' pk=traintimetable.id %}">
                     +Res
                   </a>
+                  {% endif %}
                   {% endif %}
                 </td>
               </tr>


### PR DESCRIPTION
closes https://dvzo.atlassian.net/browse/DVZO-147

+Res link is only shown if reservations (internal) are possible for the traintimetable

![image](https://user-images.githubusercontent.com/4928509/123321931-e65f8480-d533-11eb-9300-732445ccd511.png)
